### PR TITLE
Even more catching up and some fixes.

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -51,10 +51,10 @@ extern Widget g_main_w;
 extern XtAppContext g_app;
 extern int g_ready;
 
-void ui_setup_file_menu(Widget menubar);
-void ui_setup_edit_menu(Widget menubar);
-void ui_setup_image_menu(Widget menubar);
-void ui_setup_view_menu(Widget menubar);
+void ui_setup_file_menu(Widget menuBar);
+void ui_setup_edit_menu(Widget menuBar);
+void ui_setup_image_menu(Widget menuBar);
+void ui_setup_view_menu(Widget menuBar);
 
 Widget ui_setup_tool_area(Widget parent);
 Widget ui_setup_command_area(Widget parent);

--- a/ui_main.c
+++ b/ui_main.c
@@ -36,6 +36,7 @@ int g_ready = 0;
 
 
 Widget about_dialog = NULL;
+char* help_url = "https://github.com/justinmeiners/classic-colors";
 
 static void about_destroy_()
 {
@@ -84,7 +85,7 @@ static int open_url_(const char* url)
 
 static void cb_open_website_()
 {
-    open_url_("https://github.com/justinmeiners/classic-colors");
+    open_url_(help_url);//this needs to be changed around, for instance- what happens if the file is installed in "/opt"?
     XtDestroyWidget(about_dialog);
     about_dialog = NULL;
 }
@@ -194,7 +195,7 @@ Widget ui_setup_menu(Widget parent)
     XmString image_str = XmStringCreateLocalized("Image");
     XmString help_str = XmStringCreateLocalized("Help");
 
-    Widget menubar = XmVaCreateSimpleMenuBar(parent, "menubar",
+    Widget menuBar = XmVaCreateSimpleMenuBar(parent, "menuBar",
             XmVaCASCADEBUTTON, file_str, 'F',
             XmVaCASCADEBUTTON, edit_str, 'E',
             XmVaCASCADEBUTTON, view_str, 'V',
@@ -207,18 +208,18 @@ Widget ui_setup_menu(Widget parent)
     XmStringFree(edit_str);
     XmStringFree(file_str);
 
-    ui_setup_file_menu(menubar);
-    ui_setup_edit_menu(menubar);
-    ui_setup_image_menu(menubar);
-    ui_setup_view_menu(menubar);
+    ui_setup_file_menu(menuBar);
+    ui_setup_edit_menu(menuBar);
+    ui_setup_image_menu(menuBar);
+    ui_setup_view_menu(menuBar);
 
     XmString manual_str = XmStringCreateLocalized("Manual");
     XmString about_str = XmStringCreateLocalized("About");
 
-    Widget help_button = XmCreateCascadeButton(menubar, "Help", NULL, 0);
-    XtVaSetValues(menubar, XmNmenuHelpWidget, help_button, NULL);
+    Widget help_button = XmCreateCascadeButton(menuBar, "Help", NULL, 0);
+    XtVaSetValues(menuBar, XmNmenuHelpWidget, help_button, NULL);
 
-    Widget help_bar = XmVaCreateSimplePulldownMenu(menubar, "help_menu",
+    Widget help_bar = XmVaCreateSimplePulldownMenu(menuBar, "help_menu",
             -1, cb_help_menu_,
             XmVaPUSHBUTTON, manual_str, 'M', NULL, NULL,
             XmVaPUSHBUTTON, about_str, 'A', NULL, NULL,
@@ -230,9 +231,9 @@ Widget ui_setup_menu(Widget parent)
     XmStringFree(about_str);
 
     XtManageChild(help_button);
-    XtManageChild(menubar);
+    XtManageChild(menuBar);
 
-    return menubar;
+    return menuBar;
 }
 
 #if DEBUG_LOG

--- a/ui_main.c
+++ b/ui_main.c
@@ -36,7 +36,7 @@ int g_ready = 0;
 
 
 Widget about_dialog = NULL;
-char* help_url = "https://github.com/justinmeiners/classic-colors";
+char* help_url = "/usr/local/share/classic-colors/help/classic-colors_help-en.html";
 
 static void about_destroy_()
 {
@@ -85,7 +85,7 @@ static int open_url_(const char* url)
 
 static void cb_open_website_()
 {
-    open_url_(help_url);//this needs to be changed around, for instance- what happens if the file is installed in "/opt"?
+    open_url_("https://github.com/justinmeiners/classic-colors");
     XtDestroyWidget(about_dialog);
     about_dialog = NULL;
 }
@@ -148,7 +148,7 @@ static void cb_help_menu_(Widget widget, XtPointer a, XtPointer call_data)
     {
         case 0:
         {
-            open_url_("/usr/local/share/classic-colors/help/classic-colors_help-en.html");
+            open_url_(help_url);//this needs to be changed around, for instance- what happens if the file is installed in "/opt"?
             break;
         }
         case 1:


### PR DESCRIPTION
I have been out an while, adjusted menubar naming to be in line with common motif app standards(Setting *menuBar in xdefaults should work uniformly with motif apps in general) and added in a start to non-fixed HTML help locations(Attempting to not trust the old defaults as package managers my be silly in putting down spots), also had to put in an correction to the first commit.